### PR TITLE
增加 code转token登入功能

### DIFF
--- a/backend/user/models.py
+++ b/backend/user/models.py
@@ -1,9 +1,8 @@
 from django.db import models
+from django.db.models.signals import pre_save, post_save
+from django.dispatch import receiver
 from django.contrib.auth.models import User as AuthUser
-
-
-
-# Create your models here.
+from rest_framework.authtoken.models import Token
 
 class User(AuthUser):
     nickname = models.CharField(max_length=30, verbose_name='昵称')
@@ -22,3 +21,16 @@ class User(AuthUser):
         my_group = Group.objects.create(name=self.nickname+"的小组")
         Membership.objects.create(group=my_group, user=self, permission='master')
         return my_group
+
+@receiver(pre_save, sender=User, dispatch_uid="创建之前要检查密码")
+def before_create_user(instance, **kwargs):
+    if instance.id:
+        return
+    if not instance.password:
+        return
+    instance.set_password(instance.password)
+
+@receiver(post_save, sender=User, dispatch_uid="创建之后要自动生成令牌")
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)

--- a/backend/user/urls.py
+++ b/backend/user/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 from user.views.user import User
-
+from user.views.token import OAuthToken
 
 
 urlpatterns = [
     path("user/", User.as_view()),
-    path("user/<str:username>/", User.as_view())
+    path("user/<str:username>/", User.as_view()),
+    path("login/<str:code>/", OAuthToken.as_view())
 ]

--- a/backend/user/views/token.py
+++ b/backend/user/views/token.py
@@ -1,8 +1,68 @@
+'''
+登入视图
+'''
+from django.core.exceptions import ObjectDoesNotExist
+
+from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+import requests
+
+from my_utils.checker import check_are_same
+
+from user.models import User
 
 class MyTmpAuthToken(ObtainAuthToken):
-
+    '''
+    临时账号密码登入
+    '''
     def post(self, request, *args, **kwargs):
+        '''
+        临时账号密码登入
+        '''
         response = super().post(request, *args, **kwargs)
+        response.set_cookie('token', response.data['token'])
+        return response
+
+class OAuthToken(APIView):
+    '''
+    code转token登入
+    '''
+    permission_classes = ()
+
+    ACCESS_TOKEN_URL = 'http://authserver.nwu.edu.cn/authserver/oauth2.0/accessToken'
+    PROFILE_URL = 'http://authserver.nwu.edu.cn/authserver/oauthApi/user/profile'
+
+    @staticmethod
+    def post(request, code):
+        '''
+        code转token登入
+        '''
+        params = {
+            'grant_type': 'authorization_code',
+            'client_id': 'sfxzTU6D',
+            'client_secret': 'aIZr2NC1Weg7b7OeY04jhEFOjjwm0OPL',
+            'code': code,
+            'redirect_uri': 'http://localhost/'
+        }
+        token_req = requests.post(OAuthToken.ACCESS_TOKEN_URL, params=params)
+        check_are_same(token_req.status_code, 200)
+        access_token = token_req.json()['access_token']
+
+        profile_req = requests.post(OAuthToken.PROFILE_URL, params={'access_token': access_token})
+        check_are_same(profile_req.status_code, 200)
+        profile = profile_req.json()
+        username = profile['id']
+        try:
+            user = User.objects.get(username=username)
+        except ObjectDoesNotExist:
+            nickname = profile['attributes']['cn']
+            password = User.objects.make_random_password()
+            user = User.objects.create_user(username=username, nickname=nickname, password=password)
+        token = Token.objects.get(user=user)
+        # token.save() # 更新token值
+        response = Response({'token': token.key})
         response.set_cookie('token', response.data['token'])
         return response

--- a/doc/后端文档/版本.md
+++ b/doc/后端文档/版本.md
@@ -8,6 +8,7 @@
 |Django                 |2.2.2      |
 |django-mptt            |0.10.0     |
 |djangorestframework    |3.9.4      |
+|requests               |           |
 
 ## 依赖项
 


### PR DESCRIPTION
增加 code转token登入功能。

现在在admin可以直接设置 [User-用户] 密码，不做检验并hash保存。
也就是说，新建完user不必再去 [认证和授权-用户] 那里重新设置密码。